### PR TITLE
Add post-provisioning infrastructure tests with Chef Inspec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,47 @@
 version: 2.1
 
 jobs:
-  infra:
+
+  infra_build:
     docker:
       - image: hashicorp/terraform:0.12.26
     environment:
-      GOOGLE_APPLICATION_CREDENTIALS: /gcp.json
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp.json
     steps:
       - checkout
-      - run: echo $GCP_KEY >> /gcp.json
-      - run: cd ./ops/cloud && terraform init -backend-config="bucket=${GCP_PROJECT}-tf"
-      - run: cd ./ops/cloud && terraform apply -var="gcp_project=${GCP_PROJECT}" -lock=true -refresh=true -auto-approve
+      - run:
+          name: Add Key
+          command: echo $GCP_KEY > /tmp/gcp.json
+      - run:
+          name: Initialise Terraform
+          command: cd ./ops/cloud && terraform init -backend-config="bucket=${GCP_PROJECT}-tf"
+      - run:
+          name: Apply Terraform
+          command: cd ./ops/cloud && terraform apply -var="gcp_project=${GCP_PROJECT}" -lock=true -refresh=true -auto-approve
+
+  infra_test:
+    docker:
+      - image: circleci/ruby:2.5.1
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp.json
+      CHEF_LICENSE: accept-no-persist
+    steps:
+      - checkout
+      - run:
+          name: Add Key
+          command: echo $GCP_KEY > /tmp/gcp.json
+      - run:
+          name: Install InSpec
+          command: gem install inspec-bin -v 4.21.3
+      - run:
+          name: Run InSpec
+          command: cd ./ops/tests && inspec exec . -t gcp:// --chef-license=accept-no-persist --input gcp_project_id=$GCP_PROJECT
 
 workflows:
   version: 2
   run:
     jobs:
-      - infra
+      - infra_build
+      - infra_test:
+          requires:
+            - infra_build

--- a/ops/tests/README.md
+++ b/ops/tests/README.md
@@ -1,0 +1,66 @@
+# Example InSpec Profile For GCP
+
+This example shows the implementation of an InSpec profile for GCP that depends on the [InSpec GCP Resource Pack](https://github.com/inspec/inspec-gcp).  See the [README](https://github.com/inspec/inspec-gcp) for instructions on setting up appropriate GCP credentials.
+
+##  Create a profile
+
+```
+$ inspec init profile --platform gcp my-profile
+Create new profile at /Users/spaterson/my-profile
+ * Create directory libraries
+ * Create file README.md
+ * Create directory controls
+ * Create file controls/example.rb
+ * Create file inspec.yml
+ * Create file attributes.yml
+ * Create file libraries/.gitkeep
+
+```
+
+## Update `attributes.yml` to point to your project
+
+```
+gcp_project_id: 'my-gcp-project'
+```
+
+## Run the tests
+
+```
+$ cd gcp-profile/
+$ inspec exec . -t gcp:// --attrs attributes.yml
+
+Profile: GCP InSpec Profile (my-profile)
+Version: 0.1.0
+Target:  gcp://local-service-account@my-gcp-project.iam.gserviceaccount.com
+
+  ✔  gcp-single-region-1.0: Ensure single region has the correct properties.
+     ✔  Region europe-west2 zone_names should include "europe-west2-a"
+  ✔  gcp-regions-loop-1.0: Ensure regions have the correct properties in bulk.
+     ✔  Region asia-east1 should be up
+     ✔  Region asia-northeast1 should be up
+     ✔  Region asia-south1 should be up
+     ✔  Region asia-southeast1 should be up
+     ✔  Region australia-southeast1 should be up
+     ✔  Region europe-north1 should be up
+     ✔  Region europe-west1 should be up
+     ✔  Region europe-west2 should be up
+     ✔  Region europe-west3 should be up
+     ✔  Region europe-west4 should be up
+     ✔  Region northamerica-northeast1 should be up
+     ✔  Region southamerica-east1 should be up
+     ✔  Region us-central1 should be up
+     ✔  Region us-east1 should be up
+     ✔  Region us-east4 should be up
+     ✔  Region us-west1 should be up
+     ✔  Region us-west2 should be up
+
+
+Profile: Google Cloud Platform Resource Pack (inspec-gcp)
+Version: 0.5.0
+Target:  gcp://local-service-account@my-gcp-project.iam.gserviceaccount.com
+
+     No tests executed.
+
+Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
+Test Summary: 18 successful, 0 failures, 0 skipped
+```

--- a/ops/tests/attributes.yml
+++ b/ops/tests/attributes.yml
@@ -1,0 +1,2 @@
+# Below is to be uncommented and set with your GCP project ID:
+gcp_project_id: 'io-delineate-engine-dev'

--- a/ops/tests/controls/cluster.rb
+++ b/ops/tests/controls/cluster.rb
@@ -1,0 +1,11 @@
+title "delineate.io Infrastructure Tests"
+
+gcp_project_id = attribute("gcp_project_id")
+
+control "app-cluster-1.0" do
+  impact 1.0
+  title "Ensure application cluster is as expected"
+  describe google_container_cluster(project: gcp_project_id, location: 'europe-west2-a', name: 'app-cluster') do
+    it { should exist }
+  end
+end

--- a/ops/tests/inspec.lock
+++ b/ops/tests/inspec.lock
@@ -1,0 +1,8 @@
+---
+lockfile_version: 1
+depends:
+- name: inspec-gcp
+  resolved_source:
+    url: https://github.com/inspec/inspec-gcp/archive/master.tar.gz
+    sha256: c2fd2a3f2d42268345df0966eaf68a45100c993b7f586a5fc3600200bdecc9b7
+  version_constraints: []

--- a/ops/tests/inspec.yml
+++ b/ops/tests/inspec.yml
@@ -1,0 +1,16 @@
+name: delineateio
+title: Infrastructure tests
+license: Apache-2.0
+summary: Compliance profile for delineate.io
+version: 0.1.0
+inspec_version: '>= 4.21.3'
+attributes:
+- name: gcp_project_id
+  required: true
+  description: 'The GCP project'
+  type: string
+depends:
+- name: inspec-gcp
+  url: https://github.com/inspec/inspec-gcp/archive/master.tar.gz
+supports:
+- platform: gcp

--- a/vagrantfile
+++ b/vagrantfile
@@ -6,8 +6,6 @@ ansible_home      = "/home/vagrant/project/vm"
 
 core_playbooks    = ["bootstrap","profile","facts","docker","k8s","gcloud","proxy","go","cli","git"]
 config_playbooks  = ["profile","docker","k8s","gcloud","proxy","git"]
-core_playbooks = []
-config_playbooks = ["proxy"]
 
 Vagrant.configure("2") do |config|
 

--- a/vm/core/bootstrap.yml
+++ b/vm/core/bootstrap.yml
@@ -34,7 +34,12 @@
        - nmap=7.60-1ubuntu5
        - rpm=4.14.1+dfsg1-2
        - apache2-utils=2.4.29-1ubuntu4.13
-       - libnss3-tools=2:3.35-2ubuntu2.8
+       - libnss3-tools=2:3.35-2ubuntu2.9
+       - ruby=1:2.5.1
+       - ruby-dev=1:2.5.1
+       - gcc=4:7.4.0-1ubuntu2.3
+       - g++=4:7.4.0-1ubuntu2.3
+       - make=4.1-9.1ubuntu1
       state: present
 
    - name: Install mkcert

--- a/vm/core/cli.yml
+++ b/vm/core/cli.yml
@@ -66,3 +66,8 @@
      apt:
       name: shellcheck=0.4.6-1
       state: present
+
+   - gem:
+      name: inspec
+      version: 4.21.3
+      state: present


### PR DESCRIPTION
This commit introduces an example infrastructure test that is
implemented using Chef Inspec.  This enables tests to be performed
to validate that cloud infrastructure meets acceptance tests.  For
now there is a single compliance check to demonstrate an extensive
set of rules.

This is achieved by configuring the Inspec default files, update
the CircleCI to include the job.

In addition to the above the steps in the job with ugly names were
updated to be user friendly.