### PR TITLE
Apply Github best practices for larger projects

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# they will be requested for review when someone opens a pull request.
+*       @jf-delineate

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![CircleCI](https://circleci.com/gh/delineateio/delineateio.engine.svg?style=shield)](https://circleci.com/gh/delineateio/delineateio.engine)
 [![codebeat badge](https://codebeat.co/badges/f382bda1-32b7-406a-b793-9ae515ae8e52)](https://codebeat.co/projects/github-com-delineateio-delineateio-engine-master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/delineateio/delineateio.engine)](https://goreportcard.com/report/gtithub.com/delineateio/delineateio.engine)
+![GitHub issues](https://img.shields.io/github/issues-raw/delineateio/delineateio.engine?color=orange)
 [![Github All Releases](https://img.shields.io/github/downloads/delineateio/delineateio.engine/total.svg)](https://github.com/delineateio/delineateio.engine/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -22,9 +23,15 @@ Once the project is more elaborated then PR will be actively encouraged.  You ca
 
 ## Local Development
 
-> Specific attention has been given minimise the effort required to setup up a working development environment.
+> Specific attention has been given minimise the effort required to setup up a working development environment as this is a common pain point for contributors.
 
 The development environment has been implemented by using [hashicorp vagrant](https://www.vagrantup.com/) an automatically configured VM with all the required tools imnstalled.  For more information on `vagrant` review the offical documentation.
+
+### GCP Service Account
+
+A GCP service account needs to be present for `dev` cloud environment.  This key should be present at `~/.gcloud/delineateio.engine/dev`.
+
+> During the VM provisioning the GCP key will be mounted and used for authentication, therefore if the key is not present in the rquired location provisioning will fail.
 
 ### Required Dependencies
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+<p align="center">
+  <img alt="delineate.io" src="https://github.com/delineateio/.github/blob/master/assets/logo.png?raw=true" height="75" />
+  <h2 align="center">delineate.io</h2>
+  <p align="center">portray or describe (something) precisely.</p>
+</p>
+
+#
+
+## Our Security Policy
+
+The delineate.io team and community take all security bugs in the delineate.io platform seriously.
+
+> Our security policy is to avoid leaving the ecosystem worse than we found it. Meaning we are not planning to introduce vulnerabilities into the ecosystem.
+
+ Thank you for improving the security of delineate.io. We appreciate your efforts to disclose the issue responsibly, and will make every effort to acknowledge your contributions.
+
+Report security bugs by emailing the lead maintainers at security@delineate.io.
+
+## What We Will Do
+
+The lead maintainer will acknowledge your email within a week (7 days), and will send a more detailed response up to 48 hours after that indicating the next steps in handling your report.
+
+After the initial reply to your report, the security team will endeavor to keep you informed of the progress towards a fix and an announcement. We may ask for additional information or guidance.
+
+The delineate.io team will:
+
+* Confirm the problem and determine the affected versions
+* Audit code to find any similar problems
+* Prepare fixes for all releases still under maintenance. These fixes will be released as fast as possible
+* Report security bugs in third-party modules to the person or team maintaining the module
+
+## Security Disclosures
+
+When disclosing vulnerabilities please do the following to assist us...
+
+* Provide your name and affiliation (if any)
+* Include scope of vulnerability
+* Let us know who could use this exploit
+* Document steps to identify the vulnerability as it is important that we can reproduce your findings
+* Show how to exploit vulnerability, give us an attack scenario


### PR DESCRIPTION
A CODEOWNERS file was added to control who can make changes to what code.  This is in preparation for additional contributors.

A new SECURITY.md file was added so that the security policy for the project is clear to the community through and is shown on the menu in the GitHub project UI.

Renamed the readme.md to README.md as looking at other projects this appears to be the most common casing.

There was a missing instruction in the README.md file around the local development environment setup related to the GCP service account key location - the opportunity was taken to add this.